### PR TITLE
Adding Protobix to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     click>=6.7
     es_client>=1.1.1
     es_stats>=1.2.0
+    protobix>=1.0.1
 
 setup_requires =
     setuptools>=30.3.0
@@ -32,6 +33,7 @@ setup_requires =
     click>=6.7
     es_client>=1.1.1
     es_stats>=1.2.0
+    protobix>=1.0.1
 
 tests_require = 
     mock


### PR DESCRIPTION
This now mirrors requirements.txt, without it running `pip install .` or `python setup.py install` worked, but running any of the scripts at the command line failed.